### PR TITLE
fix: frappe framework url

### DIFF
--- a/data/foss.yml
+++ b/data/foss.yml
@@ -132,7 +132,7 @@
 
 - category: Web & Mobile Framework
   name: Frappe
-  url: https://frappe.io/
+  url: https://frappeframework.com/
 
 - category: Web & Mobile Framework
   name: Flask


### PR DESCRIPTION
Current url points to the company page & not the framework url.