### PR TITLE
Update webserver spelling

### DIFF
--- a/data/stack.yml
+++ b/data/stack.yml
@@ -46,15 +46,15 @@
   name: MySQL
   url: https://www.mysql.com/
 
-- category: Webervers and proxies
+- category: Webservers and proxies
   name: Nginx
   url: https://www.nginx.com/
 
-- category: Webervers and proxies
+- category: Webservers and proxies
   name: HAProxy
   url: https://www.haproxy.org/
 
-- category: Webervers and proxies
+- category: Webservers and proxies
   name: Kong
   url: https://konghq.com/
 


### PR DESCRIPTION
<img width="346" alt="image" src="https://github.com/user-attachments/assets/e6132ada-3cae-4a78-a8ba-c7b009a78ed0">

https://zerodha.tech/stack/

Webserver spelling is incorrect on the website