### PR TITLE
fix: Broken Links on Stack page

### DIFF
--- a/data/stack.yml
+++ b/data/stack.yml
@@ -72,7 +72,7 @@
 
 - category: Streams & Queues
   name: Benthos
-  url: https://www.benthos.dev/
+  url: https://github.com/redpanda-data/benthos
 
 - category: Observability & Monitoring
   name: Vector
@@ -108,7 +108,7 @@
 
 - category: DevOps & CI/CD
   name: Salt Stack
-  url: https://www.saltstack.com/
+  url: https://github.com/saltstack/salt
 
 - category: DevOps & CI/CD
   name: GLPI


### PR DESCRIPTION
Issues: 

2 Links on the Stack page are broken

Page Link: https://zerodha.tech/stack/

Video Checks:


1.  Salt Stack

https://github.com/user-attachments/assets/50688552-38c0-4436-9f8a-cd7e1665ee8f

2. Benthos

https://github.com/user-attachments/assets/71c8b49d-c819-46b4-a020-37e3ca852243


Solutions:

I have replaced those broken links with their GitHub Repos.


Happy Coding 😊